### PR TITLE
Allow for host_path to be optional by using a lookup

### DIFF
--- a/task_definition.tf
+++ b/task_definition.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_task_definition" "service" {
     for_each = var.service_volumes
     content {
       name = volume.value.name
-      host_path = volume.value.host_path
+      host_path = lookup(volume.value, "host_path", null)
     }
   }
 }


### PR DESCRIPTION
lookup with a default of null since the spec says host_path is optional. 

Fixes: #4 