### PR TITLE
Add wait_for_steady_state variable for aws_ecs_service resource

### DIFF
--- a/defaults.tf
+++ b/defaults.tf
@@ -16,6 +16,7 @@ locals {
   scheduling_strategy   = var.scheduling_strategy == null ? "REPLICA" : var.scheduling_strategy
   placement_constraints = var.placement_constraints == null ? [] : var.placement_constraints
   force_new_deployment  = var.force_new_deployment == null ? "no" : var.force_new_deployment
+  wait_for_steady_state  = var.wait_for_steady_state == null ? false : var.wait_for_steady_state
 
   attach_to_load_balancer = var.attach_to_load_balancer == null ? "yes" : var.attach_to_load_balancer
   service_elb_name        = var.service_elb_name == null ? "" : var.service_elb_name

--- a/service.tf
+++ b/service.tf
@@ -14,6 +14,8 @@ resource "aws_ecs_service" "service" {
 
   force_new_deployment = local.force_new_deployment == "yes"
 
+  wait_for_steady_state = local.wait_for_steady_state
+
   dynamic "network_configuration" {
     for_each = local.service_task_network_mode == "awsvpc" ? [local.subnet_ids] : []
 

--- a/spec/unit/infra/root/main.tf
+++ b/spec/unit/infra/root/main.tf
@@ -39,6 +39,8 @@ module "ecs_service" {
 
   force_new_deployment = var.force_new_deployment
 
+  wait_for_steady_state = var.wait_for_steady_state
+
   attach_to_load_balancer = var.attach_to_load_balancer
   service_elb_name = var.service_elb_name
   target_group_arn = var.target_group_arn

--- a/spec/unit/infra/root/variables.tf
+++ b/spec/unit/infra/root/variables.tf
@@ -124,3 +124,6 @@ variable "log_group_retention" {
 variable "force_new_deployment" {
   default = null
 }
+variable "wait_for_steady_state" {
+  default = null
+}

--- a/spec/unit/service_spec.rb
+++ b/spec/unit/service_spec.rb
@@ -93,6 +93,12 @@ describe 'service' do
               .with_attribute_value(:force_new_deployment, false))
     end
 
+    it 'does not wait for deployment to complete' do
+      expect(@plan)
+        .to(include_resource_creation(type: 'aws_ecs_service')
+              .with_attribute_value(:wait_for_steady_state, false))
+    end
+
     it 'does not configure VPC networking' do
       expect(@plan)
         .to(include_resource_creation(type: 'aws_ecs_service')
@@ -229,6 +235,38 @@ describe 'service' do
       expect(@plan)
         .to(include_resource_creation(type: 'aws_ecs_service')
               .with_attribute_value(:force_new_deployment, false))
+    end
+  end
+
+  describe 'when wait_for_steady_state is true' do
+    before(:context) do
+      @plan = plan(role: :root) do |vars|
+        vars.service_elb_name =
+          output(role: :prerequisites, name: 'load_balancer_name')
+        vars.wait_for_steady_state = true
+      end
+    end
+
+    it 'waits for the deployment to complete on apply' do
+      expect(@plan)
+        .to(include_resource_creation(type: 'aws_ecs_service')
+              .with_attribute_value(:wait_for_steady_state, true))
+    end
+  end
+
+  describe 'when wait_for_steady_state is false' do
+    before(:context) do
+      @plan = plan(role: :root) do |vars|
+        vars.service_elb_name =
+          output(role: :prerequisites, name: 'load_balancer_name')
+        vars.force_new_deployment = 'no'
+      end
+    end
+
+    it 'does not wait for the deployment to complete on apply' do
+      expect(@plan)
+        .to(include_resource_creation(type: 'aws_ecs_service')
+              .with_attribute_value(:wait_for_steady_state, false))
     end
   end
 

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,9 @@ variable "force_new_deployment" {
   type        = string
   default     = "no"
 }
+
+variable "wait_for_steady_state" {
+  description = "Whether or not to wait for the service deployment to complete (true or false). Defaults to false."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
We would like to have a CI pipeline failure when there is a configuration error that breaks the ECS service provisioning step (example missing container env var).

At the moment the pipeline is green even when the service is unhealthy. Specifying [the init flag in the container template](https://aws.amazon.com/about-aws/whats-new/2017/11/amazon-ecs-adds-support-for-docker-device-and-init-flags-in-container-task-definitions/) was not sufficient to change this behaviour. 

The optional argument `wait_for_steady_state` could help. https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#wait_for_steady_state

